### PR TITLE
Documentation Updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,3 +21,6 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+
+The above copyright and license notices apply to all files in this repository
+except for any file that contains its own copyright and/or license declaration.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ the accompanying [benchmarking][benchmarking_repo] repository for the KID/FID
 evaluation details.
 
 
+# Additional Examples
+
+The additional usage examples can be found in the `examples` subdirectory of
+the `uvcgan` package.
+
+
 # F.A.Q.
 
 ## I am training my model on a multi-GPU node. How to make sure that I use only one GPU?


### PR DESCRIPTION
As was [discussed](https://github.com/LS4GAN/toygan/issues/75), this PR adds two documentation changes:
1. A note to the `LICENSE` that limits the applicability of the said license
2. A note to the `README` to point the users that we have an `examples` subdir.