### PR TITLE
Better explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,37 @@ of comma-separated GPU indices. When it is set, `pytorch` will only use GPUs
 whose IDs are in the `CUDA_VISIBLE_DEVICES`.
 
 
+## What is the structure of a model directory?
+
+`uvcgan` saves each model in a separate directory that contains:
+ - `MODEL/config.json` -- model architecture, training, and evaluation
+    configurations
+ - `MODEL/net_*.pth`  -- PyTorch weights of model networks
+ - `MODEL/opt_*.pth`  -- PyTorch weights of training optimizers
+ - `MODEL/shed_*.pth` -- PyTorch weights of training schedulers
+ - `MODEL/checkpoints/` -- training checkpoints
+ - `MODEL/evals/`     -- evaluation results
+
+
+## Training fails with "Config collision detected" error
+
+`uvcgan` enforces a one-model-per-directory policy to prevent accidental
+overwrites of existing models. Each model directory must have a unique
+configuration - if you try to place a model with different settings in a
+directory that already contains a model, you'll receive a "Config collision
+detected" error.
+
+This safeguard helps prevent situations where you might accidentally lose
+trained models by starting a new training run with different parameters in the
+same directory.
+
+Solutions:
+1. To overwrite the old model: delete the old `config.json` configuration file
+   and restart the training process.
+2. To preserve the old model: modify the training script of the new model and
+   update the `label` or `outdir` configuration options to avoid collisions.
+
+
 # Contributing
 
 All contributions are welcome. To ensure code consistency among a diverse set

--- a/uvcgan/config/args.py
+++ b/uvcgan/config/args.py
@@ -62,12 +62,15 @@ class Args:
             diff = get_config_difference(old_config, self.config)
 
             raise RuntimeError(
-                (
-                    "Config collision detected in '%s'."
-                    " Current config\n%s\n"
-                    "does not match saved config\n%s\n"
-                    "Difference:\n%s"
-                ) % (self.savedir, new, old, diff)
+                f"Config collision detected in '{self.savedir}'."
+                f"\nDifference in configurations:\n{diff}"
+                "\n\nThis error occurs to prevent accidental overwriting of"
+                " existing models."
+                "\nTo resolve this, you can either:"
+                "\n  1. Overwrite the existing model:"
+                f" Delete '{self.savedir}/config.json'"
+                "\n  2. Preserve both models: Use a different directory by"
+                " changing 'label' or 'outdir' in your config"
             )
 
     @staticmethod


### PR DESCRIPTION
Hi @YHRen,

As several users and @pphuangyi mentioned, the current code produces very cryptic and confusing messages when one tries to save two models to the same directory. This PR improves the error message and adds README entries about it.

Please let me know if you think we can merge this PR at this point.